### PR TITLE
bugfix for Crossvalidate

### DIFF
--- a/R/Crossvalidate.R
+++ b/R/Crossvalidate.R
@@ -29,15 +29,17 @@ function (.data, k=5) {
   }
 
   # extract covariates
-  covs <- as.matrix(extract(ras, occurrence[, c('longitude', 'latitude')]))
+  coords <- cbind(occurrence$lon,
+                  occurrence$lat)
+  covs <- as.matrix(extract(ras, coords))
 
 
   # combine with the occurrence data
   df <- data.frame(value = occurrence$value,
                    type = occurrence$type,
                    fold = fold,
-                   longitude = occurrence$longitude,
-                   latitude = occurrence$latitude,
+                   longitude = occurrence$lon,
+                   latitude = occurrence$lat,
                    covs)
   
   names(df)[6:ncol(df)] <- names(ras)


### PR DESCRIPTION
as #118. Only appeared when it was the second of two process modules, as in:

```r
work1 <- workflow(occurrence = SpOcc(species = 'Anopheles plumbeus',
                                     extent = c(-10, 10, 45, 65)),
                  covariate = UKAir,
                  process = Chain(BiasBackground(bias = FrescaloBias, n = 300),
                                  Crossvalidate),
                  model = OptGRaF,
                  output = list(InteractiveMap,
                                PerformanceMeasures))
```