### PR TITLE
fixing GBM

### DIFF
--- a/R/GBM.R
+++ b/R/GBM.R
@@ -18,17 +18,12 @@
 #'@param shrinkage a shrinkage parameter applied to each tree in the expansion.
 #' Also known as the learning rate or step-size reduction.
 #'
-#'@param cv.folds Number of cross-validation folds to perform when selecting
-#' the optimal number of trees and calculating an internal estimate of
-#'  generalization error, returned in cv.error.
-#'
 #'@name GBM
 GBM <-
   function (.df,
             max.trees = 1000,
             interaction.depth = 5,
-            shrinkage = 0.001,
-            cv.folds = 3) {
+            shrinkage = 0.001) {
     
     zoon:::GetPackage('gbm')
     
@@ -46,13 +41,12 @@ GBM <-
                   distribution = 'bernoulli',
                   n.trees = max.trees,
                   interaction.depth = interaction.depth,
-                  shrinkage = shrinkage,
-                  cv.folds = cv.folds)
+                  shrinkage = shrinkage)
     
     # get the optimum number of trees
     n.trees <- gbm.perf(m,
                         plot.it = FALSE,
-                        method = 'cv')
+                        method = 'OOB')
     
     # set this in m
     m$n.trees <- n.trees

--- a/man/GBM.Rd
+++ b/man/GBM.Rd
@@ -4,8 +4,7 @@
 \alias{GBM}
 \title{Model module: GBM}
 \usage{
-GBM(.df, max.trees = 1000, interaction.depth = 5, shrinkage = 0.001,
-  cv.folds = 3)
+GBM(.df, max.trees = 1000, interaction.depth = 5, shrinkage = 0.001)
 }
 \arguments{
 \item{.df}{\strong{Internal parameter, do not use in the workflow function}.
@@ -22,10 +21,6 @@ The number of trees is equivalent to the number of iterations and
 
 \item{shrinkage}{a shrinkage parameter applied to each tree in the expansion.
 Also known as the learning rate or step-size reduction.}
-
-\item{cv.folds}{Number of cross-validation folds to perform when selecting
-the optimal number of trees and calculating an internal estimate of
- generalization error, returned in cv.error.}
 }
 \description{
 Model module to fit a generalized boosted regression (aka boosted regression


### PR DESCRIPTION
closes #130

This should now work:

```r
work1 <- workflow(occurrence = UKAnophelesPlumbeus,
                  covariate  = UKAir,
                  process    = OneHundredBackground,
                  model      = GBM,
                  output     = PrintMap)
```

although GBM quite rightly outputs this warning (among others)
```
In gbm.perf(m, plot.it = FALSE, method = "OOB") :
  OOB generally underestimates the optimal number of iterations although predictive performance is reasonably competitive. Using cv.folds>0 when calling gbm usually results in improved predictive performance.
```