### PR TITLE
family tags added for all modules

### DIFF
--- a/R/AirNCEP.R
+++ b/R/AirNCEP.R
@@ -5,6 +5,7 @@
 #'
 #'@seealso \code{\link{RNCEP::NCEP.gather}}
 #'@name AirNCEP
+#'@family covariate
 AirNCEP <- function(){
   zoon:::GetPackage(RNCEP)
   

--- a/R/AnophelesPlumbeus.R
+++ b/R/AnophelesPlumbeus.R
@@ -9,7 +9,7 @@
 #'
 #'
 #'@name AnophelesPlumbeus
-
+#'@family occurrence
 
 
 AnophelesPlumbeus <- function(extent = c(-10, 10, 45, 65)){

--- a/R/Background.R
+++ b/R/Background.R
@@ -8,6 +8,7 @@
 #'@param n the number of background points to sample
 #'
 #'@name Background
+#'@family process
 Background <- function (.data, n = 100) {
   
   zoon:::GetPackage(dismo)

--- a/R/BackgroundAndCrossvalid.R
+++ b/R/BackgroundAndCrossvalid.R
@@ -9,6 +9,7 @@
 #'@param k The number of folds you wish to have. Will later implement a leaveoneout opt
 #'
 #'@name BackgroundAndCrossvalid
+#'@family process
 BackgroundAndCrossvalid <- function (.data, k=5) {
   
   occurrence <- .data$df

--- a/R/BiasBackground.R
+++ b/R/BiasBackground.R
@@ -18,6 +18,7 @@
 #'
 #'@author Nick Golding
 #'@name BiasBackground
+#'@family process
 BiasBackground <- function (.data, bias, n = 100) {
   
   # get the internal data

--- a/R/Bioclim.R
+++ b/R/Bioclim.R
@@ -7,6 +7,7 @@
 #'@param resolution Resolution in minutes. Must be one of 2.5, 5 or 10. Default is 5. 
 #'
 #'@name Bioclim
+#'@family covariate
 Bioclim <-
 function(extent, resolution = 5) {
     

--- a/R/BiomodModel.R
+++ b/R/BiomodModel.R
@@ -11,6 +11,7 @@
 #''GLM','GBM','GAM','CTA','ANN','SRE','FDA','MARS','RF','MAXENT' 
 #'
 #'@name BiomodModel
+#'@family model
 #'@seealso \code{\link{biomod2::BIOMOD_ModelingOptions}}
 
 

--- a/R/CWBZimbabwe.R
+++ b/R/CWBZimbabwe.R
@@ -22,6 +22,7 @@
 #'   \url{http://dx.doi.org/10.1371/journal.pone.0073432} 
 #' 
 #'@name CWBZimbabwe
+#'@family occurrence
 CWBZimbabwe <-
 function(){
   return(CWBZim)

--- a/R/Crossvalidate.R
+++ b/R/Crossvalidate.R
@@ -7,6 +7,7 @@
 #'@param k Positive integer number of folds to split the data into. Default is 5. 
 #'
 #'@name Crossvalidate
+#'@family process
 Crossvalidate <-
 function (.data, k=5) {
   

--- a/R/Figshare.R
+++ b/R/Figshare.R
@@ -17,6 +17,7 @@
 #'@param tags Character vector of searchable tags. 
 #'
 #'@name Figshare
+#'@family output
 Figshare <-
 function (.model, .ras, title, description='zoon workflow', authors='zoon', categories='SDM', tags='zoon'){
 

--- a/R/GBM.R
+++ b/R/GBM.R
@@ -19,6 +19,7 @@
 #' Also known as the learning rate or step-size reduction.
 #'
 #'@name GBM
+#'@family model
 GBM <-
   function (.df,
             max.trees = 1000,

--- a/R/InteractiveCovariateMap.R
+++ b/R/InteractiveCovariateMap.R
@@ -8,8 +8,8 @@
 #'
 #'@param which which covariate to plot.
 #' A single numeric giving the index of the covariate to plot
-
 #'@name InteractiveCovariateMap
+#'@family output
 InteractiveCovariateMap <-
   function (.model, .ras, which = 1) {
     

--- a/R/InteractiveMap.R
+++ b/R/InteractiveMap.R
@@ -8,6 +8,7 @@
 #'@param .ras \strong{Internal parameter, do not use in the workflow function}. \code{.ras} is a raster layer, brick or stack object. \code{.ras} is passed automatically in workflow from the covariate module(s) to the output module(s) and should not be passed by the user.
 #'
 #'@name InteractiveMap
+#'@family output
 InteractiveMap <- function (.model, .ras) {
     
     # This function draws inspiration from a previous version of

--- a/R/LocalOccurrenceData.R
+++ b/R/LocalOccurrenceData.R
@@ -22,6 +22,7 @@
 #'  long, lat, value.
 #'
 #'@name LocalOccurrenceData
+#'@family occurrence
 LocalOccurrenceData <-
 function(filename, occurrenceType, columns, externalValidation = FALSE){
 

--- a/R/LocalRaster.R
+++ b/R/LocalRaster.R
@@ -7,6 +7,7 @@
 #'@param filenames Either a string of the filename of the raster layer, or a list of strings of filenames to rasters that will be stacked. 
 #'
 #'@name LocalRaster
+#'@family covariate
 #'@author Tim Lucas
 #'@author Email: timcdlucas@@gmail.com
 LocalRaster <-

--- a/R/LogisticRegression.R
+++ b/R/LogisticRegression.R
@@ -7,7 +7,7 @@
 #'@seealso \code{\link{glm}}
 #'
 #'@name LogisticRegression
-
+#'@family model
 
 LogisticRegression <- function(.df){
   #if (!all(df$type %in% c('presence', 'absence', 'background'))) {

--- a/R/MaxEnt.R
+++ b/R/MaxEnt.R
@@ -19,6 +19,7 @@
 #'@seealso \code{\link{dismo::maxent}}
 #'
 #'@name MaxEnt
+#'@family model
 MaxEnt <- function(.df){
   
   zoon:::GetPackage('dismo')

--- a/R/NCEP.R
+++ b/R/NCEP.R
@@ -18,6 +18,7 @@
 #'
 #'@seealso \code{\link{RNCEP::NCEP.gather}}
 #'@name NCEP
+#'@family covariate
 NCEP <-
 function(extent, variables){
   

--- a/R/NoProcess.R
+++ b/R/NoProcess.R
@@ -9,7 +9,7 @@
 #'      covariates used to train and predict from the SDM.
 #'
 #'@name NoProcess
-
+#'@family process
 
 NoProcess <-
 function (.data) {

--- a/R/OneHundredBackground.R
+++ b/R/OneHundredBackground.R
@@ -7,6 +7,7 @@
 #'@param .data \strong{Internal parameter, do not use in the workflow function}. \code{.data} is a list of a data frame and a raster object returned from occurrence modules and covariate modules respectively. \code{.data} is passed automatically in workflow from the occurrence and covariate modules to the process module(s) and should not be passed by the user.
 #'
 #'@name OneHundredBackground
+#'@family process
 OneHundredBackground <- function (.data) {
   
   #stop('BLAH')

--- a/R/OneThousandBackground.R
+++ b/R/OneThousandBackground.R
@@ -6,7 +6,7 @@
 #'@param .data \strong{Internal parameter, do not use in the workflow function}. \code{.data} is a list of a data frame and a raster object returned from occurrence modules and covariate modules respectively. \code{.data} is passed automatically in workflow from the occurrence and covariate modules to the process module(s) and should not be passed by the user.
 #'
 #'@name OneThousandBackground
-
+#'@family process
 
 OneThousandBackground <- function (.data) {
   

--- a/R/OptGRaF.R
+++ b/R/OptGRaF.R
@@ -5,7 +5,7 @@
 #'@param .df \strong{Internal parameter, do not use in the workflow function}. \code{.df} is data frame that combines the occurrence data and covariate data. \code{.df} is passed automatically in workflow from the process module(s) to the model module(s) and should not be passed by the user.
 #'
 #'@name OptGRaF
-
+#'@family model
 
 OptGRaF <-
   function (.df) {

--- a/R/PartitionDisc.R
+++ b/R/PartitionDisc.R
@@ -13,6 +13,7 @@
 #'@author Tom August'
 #'@author tomaug@@ceh.ac.uk'
 #'@name PartitionDisc
+#'@family process
 PartitionDisc <-
   function(.data, radius = 2, buffer = 1){
     

--- a/R/PerformanceMeasures.R
+++ b/R/PerformanceMeasures.R
@@ -9,6 +9,7 @@
 #'@param threshold A chosen threshold value for measures that need 0/1 predictions 
 #'
 #'@name PerformanceMeasures
+#'@family output
 PerformanceMeasures <-
 function(.model, .ras, threshold = 0.5){
 

--- a/R/PredictNewAreaMap.R
+++ b/R/PredictNewAreaMap.R
@@ -9,7 +9,7 @@
 #'@param extent Length 4 character vector giving the new extent to be predicted over. Must be within the covariate data collected in the covariate module.
 #'
 #'@name PredictNewAreaMap
-
+#'@family output
 
 PredictNewAreaMap <- function (.model, .ras, extent) {
   

--- a/R/PrintMap.R
+++ b/R/PrintMap.R
@@ -5,8 +5,8 @@
 #'@param .model \strong{Internal parameter, do not use in the workflow function}. \code{.model} is list of a data frame (\code{data}) and a model object (\code{model}). \code{.model} is passed automatically in workflow, combining data from the model module(s) and process module(s), to the output module(s) and should not be passed by the user.
 #'
 #'@param .ras \strong{Internal parameter, do not use in the workflow function}. \code{.ras} is a raster layer, brick or stack object. \code{.ras} is passed automatically in workflow from the covariate module(s) to the output module(s) and should not be passed by the user. 
-
 #'@name PrintMap
+#'@family output
 PrintMap <-
 function (.model, .ras) {
   

--- a/R/QuickGRaF.R
+++ b/R/QuickGRaF.R
@@ -11,6 +11,7 @@
 #' or \code{NULL} in which case GRaF will calculate a fixed approximation to
 #' a sensible lengthscale.
 #'@name QuickGRaF
+#'@family model
 QuickGRaF <-
 function (.df, l = NULL) {
   

--- a/R/RandomForest.R
+++ b/R/RandomForest.R
@@ -7,7 +7,7 @@
 #'@return A model object with a valid predict method
 #'
 #'@name RandomForest
-
+#'@family model
 
 
 RandomForest <- function (.df) {

--- a/R/ResponseCurve.R
+++ b/R/ResponseCurve.R
@@ -11,6 +11,7 @@
 #'If \code{NULL}, the function is executed for all covariates, one after another.
 #'Else it should be a single numeric identifying the covariate to plot.
 #'@name ResponseCurve
+#'@family output
 ResponseCurve <- function (.model, .ras, cov = NULL) {
   
   # by default, plot all covariates

--- a/R/SameTimePlaceMap.R
+++ b/R/SameTimePlaceMap.R
@@ -10,7 +10,7 @@
 #'      cell of ras
 #'
 #'@name SameTimePlaceMap
-
+#'@family output
 
 SameTimePlaceMap <- function (.model, .ras) {
   

--- a/R/SpOcc.R
+++ b/R/SpOcc.R
@@ -25,7 +25,7 @@
 #'
 #'
 #'@name SpOcc
-
+#'@family occurrence
 
 SpOcc <-
 function(species, extent, databases = 'gbif', type = 'presence', limit = 10000){

--- a/R/SurfaceMap.R
+++ b/R/SurfaceMap.R
@@ -9,6 +9,7 @@
 #'@param dir Where to save figures. Defaults to the working directory. 
 #'
 #'@name SurfaceMap
+#'@family output
 SurfaceMap <-
 function (.model, .ras, dir='.') {
   

--- a/R/UKAir.R
+++ b/R/UKAir.R
@@ -3,7 +3,7 @@
 #'Return some UK air temperature data from NCEP. Data is bundled with package and has the extent \code{c(-10, 10, 45, 65)}.
 #'
 #'@name UKAir
-#'@keywords Covariate
+#'@family covariate
 UKAir <-
 function(){
   return(UKAirRas)

--- a/R/UKAnophelesPlumbeus.R
+++ b/R/UKAnophelesPlumbeus.R
@@ -2,6 +2,7 @@
 #'  Data taken from GBIF and has the extent \code{c(-10, 10, 45, 65)}.
 #'
 #'@name UKAnophelesPlumbeus
+#'@family occurrence
 UKAnophelesPlumbeus <-
 function(){
   return(AplumbeusOcc)

--- a/R/UKBioclim.R
+++ b/R/UKBioclim.R
@@ -9,7 +9,7 @@
 #'	Use the \code{Bioclim} module for bioclim data with other extents.
 #'
 #'@name UKBioclim
-#'@keywords Covariate
+#'@family covariate
 UKBioclim <-
   function() {
     world <- getData('worldclim', var = 'bio', res = 5)

--- a/R/mgcv.R
+++ b/R/mgcv.R
@@ -19,6 +19,7 @@
 #'  for an overview of what is available.
 #'
 #'@name mgcv
+#'@family model
 mgcv <-
   function (.df,
             k = -1,

--- a/man/AirNCEP.Rd
+++ b/man/AirNCEP.Rd
@@ -12,5 +12,9 @@ Covariate module to grab a coarse resolution mean air temperature raster from
 }
 \seealso{
 \code{\link{RNCEP::NCEP.gather}}
+
+Other covariate: \code{\link{Bioclim}};
+  \code{\link{LocalRaster}}; \code{\link{NCEP}};
+  \code{\link{UKAir}}; \code{\link{UKBioclim}}
 }
 

--- a/man/AnophelesPlumbeus.Rd
+++ b/man/AnophelesPlumbeus.Rd
@@ -15,4 +15,9 @@ AnophelesPlumbeus(extent = c(-10, 10, 45, 65))
 Occurrence module to grab *Anopheles plumbeus* (a mosquito) presence
       (presence-only) data from GBIF, in the area bounded by extent.
 }
+\seealso{
+Other occurrence: \code{\link{CWBZimbabwe}};
+  \code{\link{LocalOccurrenceData}}; \code{\link{SpOcc}};
+  \code{\link{UKAnophelesPlumbeus}}
+}
 

--- a/man/Background.Rd
+++ b/man/Background.Rd
@@ -15,4 +15,12 @@ Background(.data, n = 100)
 Process module to generate background records at random in
      cells of the covariate raster and return these along with the presence only data.
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{BiasBackground}};
+  \code{\link{Crossvalidate}}; \code{\link{NoProcess}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{OneThousandBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/BackgroundAndCrossvalid.Rd
+++ b/man/BackgroundAndCrossvalid.Rd
@@ -15,4 +15,12 @@ BackgroundAndCrossvalid(.data, k = 5)
 Process module to generate up to 100 background records at random in
      cells of ras and split all data in k folds for cross validation.
 }
+\seealso{
+Other process: \code{\link{Background}};
+  \code{\link{BiasBackground}};
+  \code{\link{Crossvalidate}}; \code{\link{NoProcess}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{OneThousandBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/BiasBackground.Rd
+++ b/man/BiasBackground.Rd
@@ -28,4 +28,12 @@ Module type: Process
 \author{
 Nick Golding
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{Background}}; \code{\link{Crossvalidate}};
+  \code{\link{NoProcess}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{OneThousandBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/Bioclim.Rd
+++ b/man/Bioclim.Rd
@@ -14,4 +14,9 @@ Bioclim(extent, resolution = 5)
 \description{
 Get worldclim environment data. Downloads then stores locally.
 }
+\seealso{
+Other covariate: \code{\link{AirNCEP}};
+  \code{\link{LocalRaster}}; \code{\link{NCEP}};
+  \code{\link{UKAir}}; \code{\link{UKBioclim}}
+}
 

--- a/man/BiomodModel.Rd
+++ b/man/BiomodModel.Rd
@@ -20,5 +20,10 @@ Model module wrapper for the biomod2 function BIOMOD_Modeling()
 }
 \seealso{
 \code{\link{biomod2::BIOMOD_ModelingOptions}}
+
+Other model: \code{\link{GBM}};
+  \code{\link{LogisticRegression}}; \code{\link{MaxEnt}};
+  \code{\link{OptGRaF}}; \code{\link{QuickGRaF}};
+  \code{\link{RandomForest}}; \code{\link{mgcv}}
 }
 

--- a/man/CWBZimbabwe.Rd
+++ b/man/CWBZimbabwe.Rd
@@ -29,4 +29,9 @@ Dryad data package:
      leuconotus} P.) in Zimbabwe. Dryad Digital Repository.
   \url{http://dx.doi.org/10.1371/journal.pone.0073432}
 }
+\seealso{
+Other occurrence: \code{\link{AnophelesPlumbeus}};
+  \code{\link{LocalOccurrenceData}}; \code{\link{SpOcc}};
+  \code{\link{UKAnophelesPlumbeus}}
+}
 

--- a/man/Crossvalidate.Rd
+++ b/man/Crossvalidate.Rd
@@ -14,4 +14,12 @@ Crossvalidate(.data, k = 5)
 \description{
 Run k fold crossvalidation. If presence absence, split presences and absences separately so folds have equally balanced data. Otherwise just sample.
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{Background}}; \code{\link{BiasBackground}};
+  \code{\link{NoProcess}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{OneThousandBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/Figshare.Rd
+++ b/man/Figshare.Rd
@@ -25,4 +25,12 @@ Figshare(.model, .ras, title, description = "zoon workflow",
 \description{
 Upload your workflow call, model, occurrance and covariate data to figshare as a RData file. Uploads privately but be aware I cannot assure the privacy of any data. This module is a work in progress, and will obviously want to upload the output from the output modules.
 }
+\seealso{
+Other output: \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/GBM.Rd
+++ b/man/GBM.Rd
@@ -26,4 +26,10 @@ Also known as the learning rate or step-size reduction.}
 Model module to fit a generalized boosted regression (aka boosted regression
 trees) model
 }
+\seealso{
+Other model: \code{\link{BiomodModel}};
+  \code{\link{LogisticRegression}}; \code{\link{MaxEnt}};
+  \code{\link{OptGRaF}}; \code{\link{QuickGRaF}};
+  \code{\link{RandomForest}}; \code{\link{mgcv}}
+}
 

--- a/man/InteractiveCovariateMap.Rd
+++ b/man/InteractiveCovariateMap.Rd
@@ -17,4 +17,12 @@ A single numeric giving the index of the covariate to plot}
 \description{
 Plot a zoomable and scrollable map of a covariate layer.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/InteractiveMap.Rd
+++ b/man/InteractiveMap.Rd
@@ -15,4 +15,12 @@ InteractiveMap(.model, .ras)
 Plot an zoomable and scrollable map of the predicted distribution
 and training data.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/LocalOccurrenceData.Rd
+++ b/man/LocalOccurrenceData.Rd
@@ -30,4 +30,9 @@ Occurrence module to format local occurrence data to be used with zoon.
  Must be a .csv file with three columns longitude, latitude and value
  in that order.
 }
+\seealso{
+Other occurrence: \code{\link{AnophelesPlumbeus}};
+  \code{\link{CWBZimbabwe}}; \code{\link{SpOcc}};
+  \code{\link{UKAnophelesPlumbeus}}
+}
 

--- a/man/LocalRaster.Rd
+++ b/man/LocalRaster.Rd
@@ -20,4 +20,9 @@ Tim Lucas
 
 Email: timcdlucas@gmail.com
 }
+\seealso{
+Other covariate: \code{\link{AirNCEP}};
+  \code{\link{Bioclim}}; \code{\link{NCEP}};
+  \code{\link{UKAir}}; \code{\link{UKBioclim}}
+}
 

--- a/man/LogisticRegression.Rd
+++ b/man/LogisticRegression.Rd
@@ -14,5 +14,10 @@ Model module to fit a simple logistic regression model
 }
 \seealso{
 \code{\link{glm}}
+
+Other model: \code{\link{BiomodModel}}; \code{\link{GBM}};
+  \code{\link{MaxEnt}}; \code{\link{OptGRaF}};
+  \code{\link{QuickGRaF}}; \code{\link{RandomForest}};
+  \code{\link{mgcv}}
 }
 

--- a/man/MaxEnt.Rd
+++ b/man/MaxEnt.Rd
@@ -27,5 +27,10 @@ development kit (which you may already have installed).
 }
 \seealso{
 \code{\link{dismo::maxent}}
+
+Other model: \code{\link{BiomodModel}}; \code{\link{GBM}};
+  \code{\link{LogisticRegression}}; \code{\link{OptGRaF}};
+  \code{\link{QuickGRaF}}; \code{\link{RandomForest}};
+  \code{\link{mgcv}}
 }
 

--- a/man/NCEP.Rd
+++ b/man/NCEP.Rd
@@ -26,5 +26,9 @@ Covariate module to grab coarse resolution environmental data from NCEP
 }
 \seealso{
 \code{\link{RNCEP::NCEP.gather}}
+
+Other covariate: \code{\link{AirNCEP}};
+  \code{\link{Bioclim}}; \code{\link{LocalRaster}};
+  \code{\link{UKAir}}; \code{\link{UKBioclim}}
 }
 

--- a/man/NoProcess.Rd
+++ b/man/NoProcess.Rd
@@ -17,4 +17,12 @@ a Raster object (class from the raster package) with the gridded
 Process module that does nothing. A place holder for if nothing should be
 done to the data before modelling.
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{Background}}; \code{\link{BiasBackground}};
+  \code{\link{Crossvalidate}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{OneThousandBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/OneHundredBackground.Rd
+++ b/man/OneHundredBackground.Rd
@@ -13,4 +13,11 @@ OneHundredBackground(.data)
 Process module to generate up to 100 background records at random in
      cells of ras and return these along with the presence only data.
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{Background}}; \code{\link{BiasBackground}};
+  \code{\link{Crossvalidate}}; \code{\link{NoProcess}};
+  \code{\link{OneThousandBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/OneThousandBackground.Rd
+++ b/man/OneThousandBackground.Rd
@@ -13,4 +13,11 @@ OneThousandBackground(.data)
 Process module to generate up to 1000 background records at random in
      cells of the covariate raster and return these along with the occurrence data.
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{Background}}; \code{\link{BiasBackground}};
+  \code{\link{Crossvalidate}}; \code{\link{NoProcess}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{PartitionDisc}}
+}
 

--- a/man/OptGRaF.Rd
+++ b/man/OptGRaF.Rd
@@ -12,4 +12,10 @@ OptGRaF(.df)
 \description{
 Model module to fit a (slow) GRaF model, with parameter optimisation.
 }
+\seealso{
+Other model: \code{\link{BiomodModel}}; \code{\link{GBM}};
+  \code{\link{LogisticRegression}}; \code{\link{MaxEnt}};
+  \code{\link{QuickGRaF}}; \code{\link{RandomForest}};
+  \code{\link{mgcv}}
+}
 

--- a/man/PartitionDisc.Rd
+++ b/man/PartitionDisc.Rd
@@ -24,4 +24,11 @@ Tom August'
 
 tomaug@ceh.ac.uk'
 }
+\seealso{
+Other process: \code{\link{BackgroundAndCrossvalid}};
+  \code{\link{Background}}; \code{\link{BiasBackground}};
+  \code{\link{Crossvalidate}}; \code{\link{NoProcess}};
+  \code{\link{OneHundredBackground}};
+  \code{\link{OneThousandBackground}}
+}
 

--- a/man/PerformanceMeasures.Rd
+++ b/man/PerformanceMeasures.Rd
@@ -16,4 +16,12 @@ PerformanceMeasures(.model, .ras, threshold = 0.5)
 \description{
 Calculate a suite of performance metrics on either crossvalidation, external validation data or (at your own risk) in-sample validation.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/PredictNewAreaMap.Rd
+++ b/man/PredictNewAreaMap.Rd
@@ -16,4 +16,12 @@ PredictNewAreaMap(.model, .ras, extent)
 \description{
 Output module. Predict a model across a new area.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PrintMap}}; \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/PrintMap.Rd
+++ b/man/PrintMap.Rd
@@ -14,4 +14,13 @@ PrintMap(.model, .ras)
 \description{
 Plot a map of predicted surface.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}};
+  \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/QuickGRaF.Rd
+++ b/man/QuickGRaF.Rd
@@ -19,4 +19,10 @@ a sensible lengthscale.}
 \description{
 Model module to fit a quick GRaF model, without parameter optimisation.
 }
+\seealso{
+Other model: \code{\link{BiomodModel}}; \code{\link{GBM}};
+  \code{\link{LogisticRegression}}; \code{\link{MaxEnt}};
+  \code{\link{OptGRaF}}; \code{\link{RandomForest}};
+  \code{\link{mgcv}}
+}
 

--- a/man/RandomForest.Rd
+++ b/man/RandomForest.Rd
@@ -15,4 +15,10 @@ A model object with a valid predict method
 \description{
 Model module to fit a simple RandomForest classification model
 }
+\seealso{
+Other model: \code{\link{BiomodModel}}; \code{\link{GBM}};
+  \code{\link{LogisticRegression}}; \code{\link{MaxEnt}};
+  \code{\link{OptGRaF}}; \code{\link{QuickGRaF}};
+  \code{\link{mgcv}}
+}
 

--- a/man/ResponseCurve.Rd
+++ b/man/ResponseCurve.Rd
@@ -19,4 +19,12 @@ Else it should be a single numeric identifying the covariate to plot.}
 Plot a detailed conditional response curve from the model
 against one covariate.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{SameTimePlaceMap}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/SameTimePlaceMap.Rd
+++ b/man/SameTimePlaceMap.Rd
@@ -18,4 +18,12 @@ A Raster object giving the probabilistic model predictions for each
 \description{
 Output module. A function for outputing the raster of the predictions from an analysis
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{ResponseCurve}}; \code{\link{SurfaceMap}}
+}
 

--- a/man/SpOcc.Rd
+++ b/man/SpOcc.Rd
@@ -32,5 +32,10 @@ Occurrence module to collect occurrence data from a number of data bases.
 }
 \seealso{
 \code{\link{spocc::occ}}
+
+Other occurrence: \code{\link{AnophelesPlumbeus}};
+  \code{\link{CWBZimbabwe}};
+  \code{\link{LocalOccurrenceData}};
+  \code{\link{UKAnophelesPlumbeus}}
 }
 

--- a/man/SurfaceMap.Rd
+++ b/man/SurfaceMap.Rd
@@ -16,4 +16,13 @@ SurfaceMap(.model, .ras, dir = ".")
 \description{
 Make a png of a map of predicted surface.
 }
+\seealso{
+Other output: \code{\link{Figshare}};
+  \code{\link{InteractiveCovariateMap}};
+  \code{\link{InteractiveMap}};
+  \code{\link{PerformanceMeasures}};
+  \code{\link{PredictNewAreaMap}}; \code{\link{PrintMap}};
+  \code{\link{ResponseCurve}};
+  \code{\link{SameTimePlaceMap}}
+}
 

--- a/man/UKAir.Rd
+++ b/man/UKAir.Rd
@@ -9,5 +9,9 @@ UKAir()
 \description{
 Return some UK air temperature data from NCEP. Data is bundled with package and has the extent \code{c(-10, 10, 45, 65)}.
 }
-\keyword{Covariate}
+\seealso{
+Other covariate: \code{\link{AirNCEP}};
+  \code{\link{Bioclim}}; \code{\link{LocalRaster}};
+  \code{\link{NCEP}}; \code{\link{UKBioclim}}
+}
 

--- a/man/UKAnophelesPlumbeus.Rd
+++ b/man/UKAnophelesPlumbeus.Rd
@@ -11,4 +11,9 @@ UKAnophelesPlumbeus()
 Return some Anopheles plumbeus data that is bundled with package.
  Data taken from GBIF and has the extent \code{c(-10, 10, 45, 65)}.
 }
+\seealso{
+Other occurrence: \code{\link{AnophelesPlumbeus}};
+  \code{\link{CWBZimbabwe}};
+  \code{\link{LocalOccurrenceData}}; \code{\link{SpOcc}}
+}
 

--- a/man/UKBioclim.Rd
+++ b/man/UKBioclim.Rd
@@ -15,5 +15,9 @@ Load Bioclim rasters at 5 degree resolution for the UK
 	see `?getData' for more details of what that function does.
 	Use the \code{Bioclim} module for bioclim data with other extents.
 }
-\keyword{Covariate}
+\seealso{
+Other covariate: \code{\link{AirNCEP}};
+  \code{\link{Bioclim}}; \code{\link{LocalRaster}};
+  \code{\link{NCEP}}; \code{\link{UKAir}}
+}
 

--- a/man/mgcv.Rd
+++ b/man/mgcv.Rd
@@ -26,4 +26,10 @@ smoothing basis to use. (eg "tp" for thin plate regression spline,
 Model module to fit a generalized additive model using generalized
 crossvalidation via the mgcv R package.
 }
+\seealso{
+Other model: \code{\link{BiomodModel}}; \code{\link{GBM}};
+  \code{\link{LogisticRegression}}; \code{\link{MaxEnt}};
+  \code{\link{OptGRaF}}; \code{\link{QuickGRaF}};
+  \code{\link{RandomForest}}
+}
 


### PR DESCRIPTION
Helpfiles now have a section listing all other modules of the same type. This is a first step towards removing zoon's need for GitHub credentials when listing module types. The next step being scraping the module types from a set of known modules' helpfiles
