### PR TITLE
remove spurious character in TargetGroupBackground

### DIFF
--- a/R/TargetGroupBackground.R
+++ b/R/TargetGroupBackground.R
@@ -2,7 +2,7 @@
 #'
 #' @title Target Group Background Data
 #'
-#' @description This module takes as one of its arguements a call to an occurrence module, these occurrence points are then used as background points. This follows the methods outlined by Phillips et al (Phillips, S. J., Dudík, M., Elith, J., Graham, C. H., Lehmann, A., Leathwick, J. and Ferrier, S. (2009), Sample selection bias and presence-only distribution models: implications for background and pseudo-absence data. Ecological Applications, 19: 181–197. doi:10.1890/07-2153.1) as a method to choose background points with similar bias to the target species presence points.
+#' @description This module takes as one of its arguements a call to an occurrence module, these occurrence points are then used as background points. This follows the methods outlined by Phillips et al (Phillips, S. J., Dudik, M., Elith, J., Graham, C. H., Lehmann, A., Leathwick, J. and Ferrier, S. (2009), Sample selection bias and presence-only distribution models: implications for background and pseudo-absence data. Ecological Applications, 19: 181-197. doi:10.1890/07-2153.1) as a method to choose background points with similar bias to the target species presence points.
 #'
 #' @details 
 #'


### PR DESCRIPTION
Changed Dudík to Dudik. Apparently Roxygen or something downstream only just started caring about that character.
I also changed an em dash to a hyphen as a first attempt