### PR TITLE
fix Travis woes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ email:
   
 ## Set up the matrix of different runs
 env:
+  global:
+    - R_MAX_NUM_DLLS=1000
   matrix:
     - r: release
       not_cran: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Depends:
     spocc,
     raster,
     mapr,
-    DataExplorer
+    DataExplorer,
+    spThin
 Imports:
     assertthat
 Suggests:


### PR DESCRIPTION
OMFG I hope this works. After 10+ hours of digging, I think this is why Travis has been failing, but local tests haven't.

The test routine attaches a whole load of packages, many of which feature compiled code.
R has an [OS-dependent limit](https://stat.ethz.ch/R-manual/R-devel/library/base/html/dynload.html) on the number of DLLs (links to compiled code) that can be loaded at any one time. apparently for the Travis containers that number was 99. Calls to the 100th DLL and later throw errors. Those errors aren't reported by `zoon:::test_module()`, only the workflow that triggered them is. This PR increases that limit to the OS-specific maximum, which apparently is 1000.

This *should* resolve the problem for the foreseeable future, though in a future iteration of the automated module testing setup, it would be safer to test each module in a fresh R session to avoid this issue.

---
Notes for future me, trying to track down this type of bug:  

Trying to replicate system-dependent failures like this in a way that you can debug is a complete pain. In the end, I managed to build a local docker image to replicate the one used in the failing Travis build.

Using [the log from a failed build](https://api.travis-ci.org/v3/job/335450589/log.txt), I found the docker image name (`travis-ci-amethyst`) and [tag name](https://quay.io/repository/travisci/ci-amethyst?tab=tags) (`packer-1503974220`), pulled and span up a container with the Travis username:
```
docker pull quay.io/travisci/ci-amethyst:packer-1503974220
docker run -it -u travis quay.io/travisci/ci-amethyst:packer-1503974220 /bin/bash
```
And then copied commands (lots of `apt-get install`, some `git clone`ing and a fair few `Rscript -e`'s) from the log to the prompt to set up the container as it was for that build.

After it was set up (right up until building and checking the package) I did a `docker commit` to stash the image, and then interactively ran commands in R to isolate where the error was popping up. Eventually I succeeded, did debug, and managed to get the error message that wasn't being reported by `testthat::test_check()`.

---

Whilst I was doing that, I also asked Travis to provide debug access to their containers. There are details on how to use it (and the inherent security issues) [here](https://docs.travis-ci.com/user/running-build-in-debug-mode/), though I never got around to trying it.

